### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ You may also choose not to build. Compiling will be slightly slower, but not tha
 To compile a C file when you've built, run the following command:
 
 ```bash
-<compiler executible> <input_file> -o <output_file>
+<compiler executable> <input_file> -o <output_file>
 ```
 
-Compiler executible could be `target/release/bcc` if you built it yourself, or `x86-{platform}-bcc` if you're using the prebuilt binary.
+Compiler executable could be `target/release/bcc` if you built it yourself, or `x86-{platform}-bcc` if you're using the prebuilt binary.
 
 To compile a C file without building, run the following command:
 


### PR DESCRIPTION
executable is misspelled as executible